### PR TITLE
Automatic zip and release with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language:
+script: zip worshipsongs.zip *.onsong
+deploy:
+  provider: releases
+  api_key:
+    secure: VvmmhA95ky4/pzpjt3nWXWvXM/Myr0PChus/Z58Po78OF9MQnscfsbgjsWeheYeV4KYkxb1wuMNlmy9FdkZrYZhNPgtpL49qWsp7KhcQgHhjSUVEMmfuuhrzjL6A2Qxoqkd1ugYpYbQxo17EEybwpycxHEeznHfHFROY3qLFtQ3FEzfjDNQrP/mfHnnUXPtkslV6AJjJ/J3kIm0veUUS9ijm54RnQp28by+obogB0bn+i4RnfqQ+BFyjzFwc7ES1fTW2zhxbt7iqrkeBdfHM3DNhsccpzjnrpiTnuPNwBFvdnsroETV3q5G4QsYYNYYdg71yF/aT4fjCcwBhPB5TesiV/AInb4jsZ97sh5nwGxPdyzO02UPoZ9F/6yVvMWYSrfJBStx5YL76q95/xkLuQO9UlstU9YHUuJyJeeUG7DH2KaixMh94ZKJ+dfAXM8qFLu0FxPX3vbeZlC71+wDWoLzHohgwUtc87yzHOKhtnlOIekcX8pawUW/jmghqMtvYaZhftfNOVFhMhZdIcsQkseq3RKCV8hDqg8ficnV/6YO9OBRieliVZTS19toHW/jC6s8H+NxTL5uWd17mM7GekfN5OMbAHSyL2vnEjWvWVsVqATOYjnznMgme/fEJTPmUznLNwgoEhw6BQDPhqV7q0MPzLJ5AaiFoMlxkH1HuszE=
+  file: worshipsongs.zip
+  on:
+    repo: jswetzen/worship
+    branch: master
+  skip_cleanup: true

--- a/Shekinah Glory.onsong
+++ b/Shekinah Glory.onsong
@@ -3,18 +3,46 @@ Artist: Cory Asbury
 Key: [F]
 Original Key: F
 
-[C]We wait for You, [Fadd9]we wait for You
-[Am]We wait for You; [G]walk in the room
+Verse:
+We wait for [C]You. We wait for [Fadd9]You
+We wait for [Am]You to walk in to [G]room
 
-[C]Here we are, standing in Your presence
-[Fadd9]Here we are, standing in Your presence
-Shekina[Am] glory come down, [G]Shekinah glory come down
+Pre-Chorus:
+[C]Here we are standing in Your presence
+[C]Here we are standing in Your presence
+[F]Shekinah Glory come down. [F]Shekinah Glory come down.
 
-Release the [C]fullness of Your [Fadd9]Spirit
-[Am]Shekinah glory come, [G]Shekinah glory come
+[Am]Here we are standing in Your presence
+[Am]Here we are standing in Your presence
+[G]Shekinah Glory come down. 
 
-[C]You move and we want more, [Fadd9]You speak and we want more
-[Am]You move and we want more; [G]we want the fullness
+Chorus:
+Release the f[C]ullness of Your S[G]pirit
+She[Dm]kinah Glory come. She[F]kinah Glory come
 
-We want more, we want more, we want more, we want more
-We want more, we want more, more of Your Spirit
+Chorus 2:
+You m[C]ove and we want more.
+You sp[G]eak and we want more
+You m[Dm]ove and we want more,
+more of Your Sp[F]irit.
+
+Instrumental:
+C    G    Dm
+  F    F    F F     F    F    F F
+ Can't get enough, can't get enough
+
+Bridge:
+I [C]can't get enough of Your presence, presence
+I [G]can't get enough of Your presence, presence
+I [Dm]can't get enough of Your presence, presence
+I c[F]an't g[F]et e[F]no[F]ugh, c[F]an't [F]get e[F]no[F]ugh
+
+Bridge 2:
+We want [C]more. We want more
+We want [G]more. We want more
+We want [Dm]more. We want more
+More of Your sp[F]irit
+
+Tag:
+The Lord has given us freedom, given us freedom
+given us joy!


### PR DESCRIPTION
I was looking for a free way to use your collection and found [Power Music Reader](https://itunes.apple.com/se/app/power-music-reader/id523120705?mt=8). It accepts zip archives for import so I automated the zipping so it’s ready for download from github whenever a new song is added! You can see the releases it creates in [my fork](https://github.com/jswetzen/worship/releases).

If you want to use this, you need to connect github to Travis  if you haven’t already, and change the secure api_key to one you’ve generated, because the one in the file now is for my repo. I can provide more detailed instructions if needed.